### PR TITLE
fix class name and args name

### DIFF
--- a/jadx-core/src/main/java/jadx/core/codegen/MethodGen.java
+++ b/jadx-core/src/main/java/jadx/core/codegen/MethodGen.java
@@ -252,6 +252,15 @@ public class MethodGen {
 				classGen.useType(code, argType);
 			}
 			code.add(' ');
+
+			if(i == 0){
+				var.setName("functionObject");
+			} else if(i == 1) {
+				var.setName("newTarget");
+			} else if (i > 2) {
+				var.setName("arg" + (i-3));
+			}
+
 			String varName = nameGen.assignArg(var);
 			if (code.isMetadataSupported() && ssaVar != null /* for fallback mode */) {
 				code.attachDefinition(VarNode.get(mth, var));

--- a/jadx-plugins/jadx-dex-input/src/main/java/jadx/plugins/input/dex/sections/DexClassData.java
+++ b/jadx-plugins/jadx-dex-input/src/main/java/jadx/plugins/input/dex/sections/DexClassData.java
@@ -52,7 +52,7 @@ public class DexClassData implements IClassData {
 
 	@Override
 	public String getType() {
-		return abcClass.getName();
+		return abcClass.getName().replace("/", ".").replace("@", ".");
 	}
 
 	public class AccessFlags {


### PR DESCRIPTION
1. replace "/" and "@" with "." in the class name, jadx parse correct package name
2. change the args name from "objx" to "functionObject" "newTarget" "arg0" "arg1" ...

